### PR TITLE
Add tests

### DIFF
--- a/test/dates/hours_after.csv
+++ b/test/dates/hours_after.csv
@@ -1,0 +1,4 @@
+time,meal,satisfaction
+2:00pm,sandwich,It was a pretty good sandwich
+4:14am,milk,I needed something to calm my tummy
+11:00am,eggs,They were delicious

--- a/test/dates/hours_before.csv
+++ b/test/dates/hours_before.csv
@@ -1,0 +1,4 @@
+time,meal,satisfaction
+12:00pm,sandwich,It was a pretty good sandwich
+4:38am,milk,I needed something to calm my tummy
+1:00pm,eggs,They were delicious

--- a/test/dates/months_after.csv
+++ b/test/dates/months_after.csv
@@ -1,0 +1,4 @@
+name,dob,dod
+James Joyce, 2 February 1882, 13 January 1941
+Lewis Carroll, 27 January 1832, 14 January 1898
+Mark Twain, 30 November 1835, 21 April 21 1910

--- a/test/dates/months_before.csv
+++ b/test/dates/months_before.csv
@@ -1,0 +1,4 @@
+name,dob,dod
+James Joyce, 2 February 1882, 13 March 1941
+Lewis Carroll, 27 January 1832, 14 January 1898
+Mark Twain, 30 October 1835, 21 April 21 1910

--- a/test/dates/slash_separated_after.csv
+++ b/test/dates/slash_separated_after.csv
@@ -1,0 +1,4 @@
+name,dob,dod
+James Joyce, 02/2/1882, 01/13/1941
+Lewis Carroll, 01/27/1832, 01/14/1898
+Mark Twain, 11/30/1835, 04/21/1910

--- a/test/dates/slash_separated_before.csv
+++ b/test/dates/slash_separated_before.csv
@@ -1,0 +1,4 @@
+name,dob,dod
+James Joyce, 2/2/1882, 3/13/1941
+Lewis Carroll, 01/27/1832, 01/14/1898
+Mark Twain, 10/30/1835, 04/21/1910

--- a/test/errors/extra_column_after.csv
+++ b/test/errors/extra_column_after.csv
@@ -1,0 +1,3 @@
+id,name,phase
+1,test,this is a test
+2,foo,yet another test,do you like it?

--- a/test/errors/extra_column_before.csv
+++ b/test/errors/extra_column_before.csv
@@ -1,0 +1,3 @@
+id,name,phase
+1,test,this is a test
+2,foo,yet another test

--- a/test/errors/missing_rows_after.csv
+++ b/test/errors/missing_rows_after.csv
@@ -1,0 +1,4 @@
+id,name,phase
+1,test,this is a test
+2,this is another test
+3,foo,yet another test

--- a/test/errors/missing_rows_before.csv
+++ b/test/errors/missing_rows_before.csv
@@ -1,0 +1,3 @@
+id,name,phase
+1,test,this is a test
+3,this is another test

--- a/test/numbers/currency_after.csv
+++ b/test/numbers/currency_after.csv
@@ -1,0 +1,4 @@
+date,item,value
+1/2/13,shoes,$35.44
+2/3/13,shirt,$65.14
+3/4/13,belt,$13.11

--- a/test/numbers/currency_before.csv
+++ b/test/numbers/currency_before.csv
@@ -1,0 +1,4 @@
+date,item,value
+1/2/13,shoes,$35.29
+2/3/13,shirt,$55.14
+3/4/13,belt,$10.00

--- a/test/numbers/simple_numbers_after.csv
+++ b/test/numbers/simple_numbers_after.csv
@@ -1,0 +1,4 @@
+id,name,balance
+1,jonmagic,2500
+2,benbalter,8888
+4,caged,6200

--- a/test/numbers/simple_numbers_before.csv
+++ b/test/numbers/simple_numbers_before.csv
@@ -1,0 +1,4 @@
+id,name,balance
+1,jonmagic,1000
+2,benbalter,9999
+3,gjtorikian,8500

--- a/test/strings/simple_string_after.csv
+++ b/test/strings/simple_string_after.csv
@@ -1,0 +1,3 @@
+author,book
+Joyce,Portrait of an Artist
+Woolf,A Room of One's Own

--- a/test/strings/simple_string_before.csv
+++ b/test/strings/simple_string_before.csv
@@ -1,0 +1,3 @@
+author,book
+Joyce,Poortrait of an Artist
+Woof,A Room of Ones Own


### PR DESCRIPTION
Some extremely rudimentary tests that cover several quantitative use cases:
- Dates tracks differences between hours, dates with words, and abbreviated dates
- Errors deals with CSVs that have "broken" as a result of an incorrect change. In these cases the differ should fall back on line diffs, the git default
- Numbers deals with whole numbers, as well as quantities
- Strings deals with words, and should probably rely on the git word matching default

/cc @jonmagic 
